### PR TITLE
Recursice dependency for sub-packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
+	go-check v0.0.0-00010101000000-000000000000 // indirect
 )
+
+replace go-check => ../go-check

--- a/result/overall.go
+++ b/result/overall.go
@@ -3,7 +3,7 @@ package result
 
 import (
 	"fmt"
-	"github.com/NETWAYS/go-check"
+	"go-check"
 	"strings"
 )
 


### PR DESCRIPTION
Not sure, if that is a good GOod way to do it, but this modifies go.mod in a slight way to enable local recursive dependencies for the go-check package, so the subpackages can include each other