### PR TITLE
ci: Always test with current go release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,18 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        go:
-          - '1.13'
-          - '1.14'
-
     steps:
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go }}
-        id: go
+      - name: Set up Go
+        uses: actions/setup-go@v2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1


### PR DESCRIPTION
This will use the golang version already installed in the environment, or download the latest.

See https://github.com/actions/setup-go