### PR TITLE
Revert "Do NOT ommit trailing semicolons in perfdata"

### DIFF
--- a/perfdata/type.go
+++ b/perfdata/type.go
@@ -47,5 +47,8 @@ func (p Perfdata) String() (s string) {
 		}
 	}
 
+	// Remove trailing semicolons
+	s = strings.TrimRight(s, ";")
+
 	return
 }


### PR DESCRIPTION
Reverts NETWAYS/go-check#36