### PR TITLE
Revert "Do NOT ommit trailing semicolons in perfdata"

### DIFF
--- a/perfdata/list_test.go
+++ b/perfdata/list_test.go
@@ -10,5 +10,5 @@ func ExamplePerfdataList() {
 	fmt.Println(list)
 
 	// Output:
-	// test1=23;;;; test2=42;;;;
+	// test1=23 test2=42
 }

--- a/perfdata/type.go
+++ b/perfdata/type.go
@@ -2,6 +2,7 @@ package perfdata
 
 import (
 	"github.com/NETWAYS/go-check"
+	"strings"
 )
 
 // Perfdata represents all properties of performance data for Icinga
@@ -45,6 +46,9 @@ func (p Perfdata) String() (s string) {
 			s += FormatNumeric(value)
 		}
 	}
+
+	// Remove trailing semicolons
+	s = strings.TrimRight(s, ";")
 
 	return
 }


### PR DESCRIPTION
Reverting an uncoordinated and little bit chaotic change...

Reverts NETWAYS/go-check#38

## Explanation

[Spec](https://www.monitoring-plugins.org/doc/guidelines.html#AEN201) lists only an example but doesn't explain the semicolons.

> 'label'=value[UOM];[warn];[crit];[min];[max]

Best practice is to remove trailing `;` as they are fully redundant. Many plugins do this and usually only add empty thresholds, when min/max is set.