### PR TITLE
perfdata: Remove strict uom handling and allow any unit

### DIFF
--- a/perfdata/type.go
+++ b/perfdata/type.go
@@ -9,27 +9,30 @@ import (
 //
 // Implements fmt.Stringer to return the plaintext format for a plugin output.
 //
-// Also see https://www.monitoring-plugins.org/doc/guidelines.html#AEN201
+// For examples of Uom see:
+//
+// https://www.monitoring-plugins.org/doc/guidelines.html#AEN201
+//
+// https://github.com/Icinga/icinga2/blob/master/lib/base/perfdatavalue.cpp
+//
+// https://icinga.com/docs/icinga-2/latest/doc/05-service-monitoring/#unit-of-measurement-uom
 type Perfdata struct {
 	Label string
 	Value interface{}
-	Uom   string
-	Warn  *check.Threshold
-	Crit  *check.Threshold
-	Min   interface{}
-	Max   interface{}
+	// Uom is the unit-of-measurement, see links above for details.
+	Uom  string
+	Warn *check.Threshold
+	Crit *check.Threshold
+	Min  interface{}
+	Max  interface{}
 }
 
 // String returns the proper format for the plugin output
 func (p Perfdata) String() (s string) {
 	s = FormatLabel(p.Label) + "="
 
-	// Value
 	s += FormatNumeric(p.Value)
-
-	if IsValidUom(p.Uom) {
-		s += p.Uom
-	}
+	s += p.Uom
 
 	// Thresholds
 	for _, value := range []*check.Threshold{p.Warn, p.Crit} {

--- a/perfdata/util.go
+++ b/perfdata/util.go
@@ -7,17 +7,8 @@ import (
 	"strings"
 )
 
-// ValidUom lists all valid units allowed by spec and Icinga 2
-//
-// Also see:
-//   - https://www.monitoring-plugins.org/doc/guidelines.html#AEN201
-//   - https://github.com/Icinga/icinga2/blob/master/lib/base/perfdatavalue.cpp
-const ValidUom = "us|ms|s|tb|gb|mb|kb|b|%|c"
-
 // Lists all allowed characters inside a label, so we can replace any non-matching
 var validInLabelRe = regexp.MustCompile(`[^a-zA-Z0-9 _\-+:/.]+`)
-
-var validUomSlice = strings.Split(ValidUom, "|")
 
 // FormatNumeric returns a string representation of various possible numerics
 //
@@ -49,15 +40,4 @@ func FormatLabel(label string) string {
 	}
 
 	return label
-}
-
-// IsValidUom compares the given unit against ValidUom
-func IsValidUom(uom string) bool {
-	for _, k := range validUomSlice {
-		if k == uom {
-			return true
-		}
-	}
-
-	return false
 }

--- a/perfdata/util_test.go
+++ b/perfdata/util_test.go
@@ -22,9 +22,3 @@ func TestFormatLabel(t *testing.T) {
 	assert.Equal(t, "t_est_x", FormatLabel("t%$%^est\t\n\\x"))
 	assert.Equal(t, "test/:x", FormatLabel("test/:x"))
 }
-
-func TestIsValidUom(t *testing.T) {
-	assert.True(t, IsValidUom("%"))
-	assert.False(t, IsValidUom(""))
-	assert.False(t, IsValidUom("X"))
-}


### PR DESCRIPTION
Basically it still is expected to use a supported unit. But Icinga recently extended the list and we will not enforce it here.