### PR TITLE
Make distinction between explicitely set states and derived ones

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - deadcode
     - structcheck
     - varcheck
+    - musttag
   presets:
     - bugs
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,9 +18,7 @@ linters:
     - deadcode
     - structcheck
     - varcheck
-    - musttag
   presets:
     - bugs
     - unused
-    # - style
   fast: false

--- a/result/overall.go
+++ b/result/overall.go
@@ -43,27 +43,27 @@ func (s *PartialResult) String() string {
 	return fmt.Sprintf("[%s] %s|%s", check.StatusText(s.State), s.Output, s.Perfdata.String())
 }
 
-// Deprecate this in a future version
+// Deprecated: Will be removed in a future version, use Add() instead
 func (o *Overall) AddOK(output string) {
 	o.Add(check.OK, output)
 }
 
-// Deprecate this in a future version
+// Deprecated: Will be removed in a future version, use Add() instead
 func (o *Overall) AddWarning(output string) {
 	o.Add(check.Warning, output)
 }
 
-// Deprecate this in a future version
+// Deprecated: Will be removed in a future version, use Add() instead
 func (o *Overall) AddCritical(output string) {
 	o.Add(check.Critical, output)
 }
 
-// Deprecate this in a future version
+// Deprecated: Will be removed in a future version, use Add() instead
 func (o *Overall) AddUnknown(output string) {
 	o.Add(check.Unknown, output)
 }
 
-// Add State
+// Add State explicitely
 // Hint: This will set stateSetExplicitely to true
 func (o *Overall) Add(state int, output string) {
 	switch state {

--- a/result/overall.go
+++ b/result/overall.go
@@ -30,7 +30,7 @@ type Overall struct {
 type PartialResult struct {
 	State               int
 	Output              string
-	stateSetExplicitely bool
+	stateSetExplicitely bool // nolint: unused
 	Perfdata            perfdata.PerfdataList
 	partialResults      []PartialResult
 }
@@ -74,6 +74,7 @@ func (o *Overall) Add(state int, output string) {
 	default:
 		o.unknowns++
 	}
+
 	o.stateSetExplicitely = true
 
 	o.Outputs = append(o.Outputs, fmt.Sprintf("[%s] %s", check.StatusText(state), output))
@@ -130,7 +131,9 @@ func (o *Overall) GetSummary() string {
 			o.Summary = "No status information"
 			return o.Summary
 		}
-	} else {
+	}
+
+	if !o.stateSetExplicitely {
 		// No, so lets combine the partial ones
 		if len(o.partialResults) == 0 {
 			// Oh, we actually don't have those either
@@ -146,13 +149,14 @@ func (o *Overall) GetSummary() string {
 		)
 
 		for _, sc := range o.partialResults {
-			if sc.State == check.Critical {
+			switch sc.State {
+			case check.Critical:
 				criticals++
-			} else if sc.State == check.Warning {
+			case check.Warning:
 				warnings++
-			} else if sc.State == check.Unknown {
+			case check.Unknown:
 				unknowns++
-			} else if sc.State == check.OK {
+			case check.OK:
 				oks++
 			}
 		}
@@ -212,6 +216,7 @@ func (s *PartialResult) getOutput(indent_level int) string {
 	return output.String()
 }
 
+// nolint: unused
 func (s *PartialResult) getState() int {
 	if s.stateSetExplicitely {
 		return s.State

--- a/result/overall.go
+++ b/result/overall.go
@@ -63,6 +63,8 @@ func (o *Overall) AddUnknown(output string) {
 	o.Add(check.Unknown, output)
 }
 
+// Add State
+// Hint: This will set stateSetExplicitely to true
 func (o *Overall) Add(state int, output string) {
 	switch state {
 	case check.OK:
@@ -75,6 +77,7 @@ func (o *Overall) Add(state int, output string) {
 		o.unknowns++
 	}
 
+	// TODO: Might be a bit obscure that the Add method also sets stateSetExplicitely
 	o.stateSetExplicitely = true
 
 	o.Outputs = append(o.Outputs, fmt.Sprintf("[%s] %s", check.StatusText(state), output))


### PR DESCRIPTION
Previously the state logic had only to deal with the overall states and not with the partialChecks.
This commit adds a condition to be able to distinguish states set directly in an Overall or Partial and the ones derived from Partials further down the tree.