### PR TITLE
Move all PartialResult Perfdata to the end of the output

### DIFF
--- a/result/overall.go
+++ b/result/overall.go
@@ -36,11 +36,7 @@ type PartialResult struct {
 }
 
 func (s *PartialResult) String() string {
-	if len(s.Perfdata) == 0 {
-		return fmt.Sprintf("[%s] %s", check.StatusText(s.State), s.Output)
-	}
-
-	return fmt.Sprintf("[%s] %s|%s", check.StatusText(s.State), s.Output, s.Perfdata.String())
+	return fmt.Sprintf("[%s] %s", check.StatusText(s.State), s.Output)
 }
 
 // Deprecated: Will be removed in a future version, use Add() instead
@@ -196,14 +192,42 @@ func (o *Overall) GetOutput() string {
 	}
 
 	if o.partialResults != nil {
+		var pdata strings.Builder
+
+		// Generate indeted output and perfdata for all partialResults
 		for i := range o.partialResults {
 			output.WriteString(o.partialResults[i].getOutput(0))
+			pdata.WriteString(" " + o.partialResults[i].getPerfdata())
+		}
+
+		pdata_string := strings.Trim(pdata.String(), " ")
+
+		if len(pdata_string) > 0 {
+			output.WriteString("|" + pdata_string + "\n")
 		}
 	}
 
 	return output.String()
 }
 
+// Returns all subsequent perfdata as a concatenated string
+func (s *PartialResult) getPerfdata() string {
+	var output strings.Builder
+
+	if len(s.Perfdata) > 0 {
+		output.WriteString(s.Perfdata.String())
+	}
+
+	if s.partialResults != nil {
+		for _, ss := range s.partialResults {
+			output.WriteString(ss.getPerfdata())
+		}
+	}
+
+	return output.String()
+}
+
+// Generates indented output for all subsequent PartialResults
 func (s *PartialResult) getOutput(indent_level int) string {
 	var output strings.Builder
 

--- a/result/overall_test.go
+++ b/result/overall_test.go
@@ -139,7 +139,8 @@ func ExampleOverall_withSubchecks() {
 	// Output:
 	// states: ok=1
 	// [OK] bla
-	// \_ [OK] Subcheck1 Test|pd_test=5s
+	// \_ [OK] Subcheck1 Test
+	// |pd_test=5s
 }
 
 func TestOverall_withEnhancedSubchecks(t *testing.T) {
@@ -182,8 +183,9 @@ func TestOverall_withEnhancedSubchecks(t *testing.T) {
 	resString := overall.GetOutput()
 	//nolint:lll
 	expectedString := `states: warning=1 ok=1
-\_ [OK] Subcheck1 Test|pd_test=5s pd_test2=1099511627776kB;@3.14:7036874417766;549755813887:1208925819614629174706176;;18446744073709551615
-\_ [WARNING] Subcheck2 Test|kl;jr2if;l2rkjasdf=5m asdf=18446744073709551615B
+\_ [OK] Subcheck1 Test
+\_ [WARNING] Subcheck2 Test
+|pd_test=5s pd_test2=1099511627776kB;@3.14:7036874417766;549755813887:1208925819614629174706176;;18446744073709551615 kl;jr2if;l2rkjasdf=5m asdf=18446744073709551615B
 `
 	assert.Equal(t, expectedString, resString)
 }
@@ -212,6 +214,7 @@ func TestOverall_withSubchecks3(t *testing.T) {
 
 	assert.Equal(t, resString, output)
 }
+
 func TestOverall_withSubchecks4(t *testing.T) {
 	var overall Overall
 
@@ -242,7 +245,8 @@ func TestOverall_withSubchecks4(t *testing.T) {
 
 	res := `states: ok=1
 \_ [OK] PartialResult
-    \_ [OK] SubSubcheck|foo=3 bar=300%
+    \_ [OK] SubSubcheck
+|foo=3 bar=300%
 `
 
 	assert.Equal(t, res, overall.GetOutput())
@@ -281,8 +285,9 @@ func TestOverall_withSubchecks5(t *testing.T) {
 
 	res := `states: ok=1
 \_ [OK] PartialResult
-    \_ [OK] SubSubcheck|foo=3 bar=300%
+    \_ [OK] SubSubcheck
         \_ [CRITICAL] SubSubSubcheck
+|foo=3 bar=300%
 `
 
 	assert.Equal(t, res, overall.GetOutput())


### PR DESCRIPTION
Fixes #62 