### PR TITLE
Remove deprecated functions

### DIFF
--- a/exit.go
+++ b/exit.go
@@ -48,13 +48,6 @@ func ExitRaw(rc int, output ...string) {
 	BaseExit(rc)
 }
 
-// Exit prints the plugin output and exits the program
-//
-// Deprecated, please use Exitf or ExitRaw.
-func Exit(rc int, output string, args ...interface{}) {
-	Exitf(rc, output, args...)
-}
-
 func BaseExit(rc int) {
 	if AllowExit {
 		os.Exit(rc)

--- a/http/mock/mock.go
+++ b/http/mock/mock.go
@@ -3,4 +3,5 @@
 // Features:
 // - RegisterQueryMapResponder form query based based on a QueryMap
 // - ActivateRecorder to record HTTP requests during the development of tests and examples
+// Deprecated: Will be removed in a future version
 package checkhttpmock

--- a/result/overall.go
+++ b/result/overall.go
@@ -42,26 +42,6 @@ func (s *PartialResult) String() string {
 	return fmt.Sprintf("[%s] %s", check.StatusText(s.GetStatus()), s.Output)
 }
 
-// Deprecated: Will be removed in a future version, use Add() instead
-func (o *Overall) AddOK(output string) {
-	o.Add(check.OK, output)
-}
-
-// Deprecated: Will be removed in a future version, use Add() instead
-func (o *Overall) AddWarning(output string) {
-	o.Add(check.Warning, output)
-}
-
-// Deprecated: Will be removed in a future version, use Add() instead
-func (o *Overall) AddCritical(output string) {
-	o.Add(check.Critical, output)
-}
-
-// Deprecated: Will be removed in a future version, use Add() instead
-func (o *Overall) AddUnknown(output string) {
-	o.Add(check.Unknown, output)
-}
-
 // Add State explicitely
 // Hint: This will set stateSetExplicitely to true
 func (o *Overall) Add(state int, output string) {

--- a/result/overall_test.go
+++ b/result/overall_test.go
@@ -151,7 +151,7 @@ func ExampleOverall_withSubchecks() {
 	subcheck.SetState(check.OK)
 
 	overall.AddSubcheck(subcheck)
-	overall.AddOK("bla")
+	overall.Add(0, "bla")
 
 	fmt.Println(overall.GetOutput())
 	// Output:


### PR DESCRIPTION
As discussed, with v0.5.0 we remove these already deprecated functions and mark http/mock as deprecated

- Remove deprecated Add Functions
- Remove deprecated Exit() function
- Add deprecation notice to http/mock module
