### PR TITLE
Extend perfdata character set to remove double quotes

### DIFF
--- a/perfdata/type.go
+++ b/perfdata/type.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Replace not allowed characters inside a label
-var replacer = strings.NewReplacer("=", "_", "`", "_", "'", "_")
+var replacer = strings.NewReplacer("=", "_", "`", "_", "'", "_", "\"", "_")
 
 // formatNumeric returns a string representation of various possible numerics
 //

--- a/perfdata/type_test.go
+++ b/perfdata/type_test.go
@@ -37,6 +37,13 @@ func TestRenderPerfdata(t *testing.T) {
 			},
 			expected: "test=2",
 		},
+		"with-quotes": {
+			perf: Perfdata{
+				Label: "te's\"t",
+				Value: 2,
+			},
+			expected: "te_s_t=2",
+		},
 		"with-special-chars": {
 			perf: Perfdata{
 				Label: "test_🖥️_'test",


### PR DESCRIPTION
I think double quotes should also be removed from the perfdata names. Otherwise this could probably have some side effects for rendering.