### PR TITLE
Proposal: Add LoadFromEnv function

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51
+          version: v1.54

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
-  deadline: 1m
-  skip-files:
-    - '(.+)_test\.go'
-
+  timeout: 5m
+  tests: false
 linters:
   disable-all: false
   enable:

--- a/config_test.go
+++ b/config_test.go
@@ -26,8 +26,9 @@ func ExampleConfig() {
 }
 
 type ConfigForTesting struct {
-	Auth   string `env:"AUTH"`
-	Bearer string `env:"EXAMPLE"`
+	Auth            string `env:"AUTH"`
+	Bearer          string `env:"EXAMPLE"`
+	OneMoreThanTags string
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -42,4 +43,5 @@ func TestLoadFromEnv(t *testing.T) {
 
 	assert.Equal(t, "foobar", c.Bearer)
 	assert.Equal(t, "", c.Auth)
+	assert.Equal(t, "", c.OneMoreThanTags)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,5 +1,12 @@
 package check
 
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
 func ExampleConfig() {
 	config := NewConfig()
 	config.Name = "check_test"
@@ -16,4 +23,23 @@ func ExampleConfig() {
 
 	// Output: [OK] - Everything is fine - answer=42
 	// would exit with code 0
+}
+
+type ConfigForTesting struct {
+	Auth   string `env:"AUTH"`
+	Bearer string `env:"EXAMPLE"`
+}
+
+func TestLoadFromEnv(t *testing.T) {
+	c := ConfigForTesting{}
+
+	err := os.Setenv("EXAMPLE", "foobar")
+	defer os.Unsetenv("EXAMPLE") // just to not create any side effects
+
+	assert.NoError(t, err)
+
+	LoadFromEnv(&c)
+
+	assert.Equal(t, "foobar", c.Bearer)
+	assert.Equal(t, "", c.Auth)
 }


### PR DESCRIPTION
I propose we add a generic function to load configuration from environment variables.
Mainly to avoid passing secrets via the CLI.

:no_good: 

```bash
check_foo --user markus --password MyCatsNameisMittens
```

:ok_person: 

```bash
export PASSWORD=MyCatsNameisMittens

check_foo --user markus
```

I quickly threw a `LoadFromEnv`  function together that can be used to load struct values from 'env' tags.

```
type Config struct {
  Token    string `env:"BEARER_TOKEN"` 
}

LoadFromEnv(&c)
```

I'm not too happy with the function's `interface{}` paramter yet.
