### PR TITLE
Resolve states of partial results recursively and now correctly

### DIFF
--- a/result/overall.go
+++ b/result/overall.go
@@ -324,7 +324,7 @@ func (s *PartialResult) GetStatus() int {
 	states := make([]int, len(s.PartialResults))
 
 	for i := range s.PartialResults {
-		states[i] = s.PartialResults[i].state
+		states[i] = s.PartialResults[i].GetStatus()
 	}
 
 	return WorstState(states...)

--- a/result/overall_test.go
+++ b/result/overall_test.go
@@ -323,15 +323,15 @@ func TestOverall_withSubchecks_PartialResult(t *testing.T) {
 
 	overall.AddSubcheck(subcheck)
 
-	res := `states: ok=1
-\_ [OK] PartialResult
+	res := `states: critical=1
+\_ [CRITICAL] PartialResult
     \_ [CRITICAL] SubSubcheck
         \_ [CRITICAL] SubSubSubcheck
 |foo=3 bar=300% baz=23B
 `
 
 	assert.Equal(t, res, overall.GetOutput())
-	assert.Equal(t, 0, overall.GetStatus())
+	assert.Equal(t, check.Critical, overall.GetStatus())
 }
 
 func TestOverall_withSubchecks_PartialResultStatus(t *testing.T) {


### PR DESCRIPTION
This patch fixes a bug which causes PartialResults to show "wrong" states, when the state is derived from other PartialResults inside.

The problem was a small piece of code which was forgotten, when the "explicit state" logic was introduced.