### PR TITLE
Add initializer for PartialResult

### DIFF
--- a/result/overall.go
+++ b/result/overall.go
@@ -41,6 +41,8 @@ type PartialResult struct {
 	defaultStateSet    bool // nolint: unused
 }
 
+// Initializer for a PartialResult with "sane" defaults
+// Notable default compared to the nil object: the default state is set to Unknown
 func NewPartialResult() PartialResult {
 	return PartialResult{
 		stateSetExplicitly: false,

--- a/result/overall.go
+++ b/result/overall.go
@@ -41,6 +41,13 @@ type PartialResult struct {
 	defaultStateSet    bool // nolint: unused
 }
 
+func NewPartialResult() PartialResult {
+	return PartialResult{
+		stateSetExplicitly: false,
+		defaultState:       check.Unknown,
+	}
+}
+
 // String returns the status and output of the PartialResult
 func (s *PartialResult) String() string {
 	return fmt.Sprintf("[%s] %s", check.StatusText(s.GetStatus()), s.Output)


### PR DESCRIPTION
This commit adds a NewPartialResult function which returns a PartialResult struct with "sane" default, mainly setting the defaultState to "Unknown".

This should help developers implementing this library, since it avoids the following pattern:

sc := result.PartialResult{}
sc.setDefaultState(check.Unknown)

This pattern is quite common, but in a sense useless.