### PR TITLE
docs(readme): Update PartialResult example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,11 @@ o := Overall{}
 o.Add(0, "Something is OK")
 
 pr := PartialResult{
-    State:  check.OK,
     Output: "My Subcheck",
+}
+
+if err := pr.SetState(check.OK); err != nil {
+  fmt.Printf(%s, err)
 }
 
 o.AddSubcheck(pr)


### PR DESCRIPTION
Apparently, the public field `State` of the `PartialResult` struct has been made private and needs to be set via `SetState()` now.