### PR TITLE
Add helper function to transform string states into int states

### DIFF
--- a/exit.go
+++ b/exit.go
@@ -33,7 +33,9 @@ func Exitf(rc int, output string, args ...interface{}) {
 func ExitRaw(rc int, output ...string) {
 	var text strings.Builder
 
-	text.WriteString("[" + StatusText(rc) + "] -")
+	status, _ := GetStatusText(rc)
+
+	text.WriteString("[" + status + "] -")
 
 	for _, s := range output {
 		text.WriteString(" " + s)

--- a/result/overall.go
+++ b/result/overall.go
@@ -56,7 +56,8 @@ func NewPartialResult() PartialResult {
 
 // String returns the status and output of the PartialResult
 func (s *PartialResult) String() string {
-	return fmt.Sprintf("[%s] %s", check.StatusText(s.GetStatus()), s.Output)
+	status, _ := check.GetStatusText(s.GetStatus())
+	return fmt.Sprintf("[%s] %s", status, s.Output)
 }
 
 // Add adds a return state explicitly
@@ -77,7 +78,9 @@ func (o *Overall) Add(state int, output string) {
 	// TODO: Might be a bit obscure that the Add method also sets stateSetExplicitly
 	o.stateSetExplicitly = true
 
-	o.Outputs = append(o.Outputs, fmt.Sprintf("[%s] %s", check.StatusText(state), output))
+	status, _ := check.GetStatusText(state)
+
+	o.Outputs = append(o.Outputs, fmt.Sprintf("[%s] %s", status, output))
 }
 
 // AddSubcheck adds a PartialResult to the Overall

--- a/status.go
+++ b/status.go
@@ -1,5 +1,10 @@
 package check
 
+import (
+	"fmt"
+	"strings"
+)
+
 const (
 	// OK means everything is fine
 	OK       = 0
@@ -15,17 +20,37 @@ const (
 	UnknownString = "UNKNOWN"
 )
 
-// StatusText returns the string corresponding to a state
-func StatusText(status int) string {
+// GetStatusText returns the string corresponding to a state
+func GetStatusText(status int) (string, error) {
 	switch status {
 	case OK:
-		return OKString
+		return OKString, nil
 	case Warning:
-		return WarningString
+		return WarningString, nil
 	case Critical:
-		return CriticalString
+		return CriticalString, nil
 	case Unknown:
+		return UnknownString, nil
 	}
 
-	return UnknownString
+	return "", fmt.Errorf("no status text for status: %d", status)
+}
+
+// GetStatusInt returns a state corresponding to its
+// common string representation
+func GetStatusInt(status string) (int, error) {
+	status = strings.ToUpper(status)
+
+	switch status {
+	case OKString, "0":
+		return OK, nil
+	case WarningString, "1":
+		return Warning, nil
+	case CriticalString, "2":
+		return Critical, nil
+	case UnknownString, "3":
+		return Unknown, nil
+	}
+
+	return -1, fmt.Errorf("no integer for status: %s", status)
 }

--- a/status_test.go
+++ b/status_test.go
@@ -29,10 +29,48 @@ func TestStatusText(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			actual := StatusText(tc.input)
+			actual, _ := GetStatusText(tc.input)
 
 			if actual != tc.expected {
 				t.Fatalf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestStatusInt(t *testing.T) {
+	testcases := map[string]struct {
+		input    string
+		expected int
+	}{
+		"OK": {
+			expected: 0,
+			input:    "OK",
+		},
+		"WARNING": {
+			expected: 1,
+			input:    "warning",
+		},
+		"CRITICAL": {
+			expected: 2,
+			input:    "Critical",
+		},
+		"UNKNOWN": {
+			expected: 3,
+			input:    "unknown",
+		},
+		"Invalid-Input": {
+			expected: -1,
+			input:    "Something else",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual, _ := GetStatusInt(tc.input)
+
+			if actual != tc.expected {
+				t.Error("\nActual: ", actual, "\nExpected: ", tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a  helper function to transform string states into int states. 
It's the invert of the existing `StatusText`.

Unsure if this should should return an error if "invalid input" is given, the `StatusInt` doesn't so I decided to go for consistency.

While writing this, I thought: is there a reason we don't have a "Status" type with these methods attached? :thinking: 

See #125 