### PR TITLE
Ignore string case in NewStatusFromString

### DIFF
--- a/status.go
+++ b/status.go
@@ -3,6 +3,7 @@ package check
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -45,7 +46,8 @@ func NewStatus(status int) (Status, error) {
 // NewStatusFromString returns a state corresponding to its
 // common string representation
 func NewStatusFromString(status string) (Status, error) {
-	switch status {
+	s := strings.ToUpper(status)
+	switch s {
 	case OKString:
 		return OK, nil
 	case WarningString:
@@ -70,7 +72,7 @@ func (s Status) String() string {
 		return CriticalString
 	case Unknown:
 		return UnknownString
+	default:
+		return UnknownString
 	}
-
-	return UnknownString
 }

--- a/status_test.go
+++ b/status_test.go
@@ -51,12 +51,24 @@ func TestStatus_FromString(t *testing.T) {
 			input:    "WARNING",
 			expected: Warning,
 		},
+		"WaRnInG": {
+			input:    "WaRnInG",
+			expected: Warning,
+		},
 		"CRITICAL": {
 			input:    "CRITICAL",
 			expected: Critical,
 		},
+		"Critical": {
+			input:    "Critical",
+			expected: Critical,
+		},
 		"UNKNOWN": {
 			input:    "UNKNOWN",
+			expected: Unknown,
+		},
+		"unknown": {
+			input:    "unknown",
 			expected: Unknown,
 		},
 	}
@@ -69,6 +81,18 @@ func TestStatus_FromString(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tc.expected, actual)
 			}
 		})
+	}
+}
+
+func TestStatus_FromString_WithErr(t *testing.T) {
+	actual, err := NewStatusFromString("unittest")
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if actual != Unknown {
+		t.Fatalf("expected Unknown, got %v", actual)
 	}
 }
 
@@ -103,5 +127,17 @@ func TestStatus_FromInt(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tc.expected, actual)
 			}
 		})
+	}
+}
+
+func TestStatus_FromInt_WithErr(t *testing.T) {
+	actual, err := NewStatus(1337)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if actual != Unknown {
+		t.Fatalf("expected Unknown, got %v", actual)
 	}
 }


### PR DESCRIPTION
Since the string might come any source I find myself normalizing these anyways. I know the downstream project could also do this, but why not do it here.

e.g
- check_prometheus/cmd/alert.go
- check_elasticsearch/cmd/snapshot.go